### PR TITLE
Updating voila-embed component

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Example
 
 In the example directory run:
 ```
-$ voila --no-browser --template=embed --enable_nbextensions=True --Voila.tornado_settings="{'allow_origin': 'http://localhost:8080'}" --port=8000
+$ voila --no-browser --template=embed --enable_nbextensions=True --Voila.tornado_settings="{'allow_origin': 'http://localhost:8080', 'allow_credentials': True}" --port=8000
 ```
 
 In another terminal in the example directory run:
@@ -79,7 +79,7 @@ Install the library:
 $ yarn add voila-embed-vuetify
 ```
 
-Add voila-embed-vuetify to `transpileDependencies` in `vue.config.js` 
+Add voila-embed-vuetify to `transpileDependencies` in `vue.config.js`
 ```javascript
 module.exports = {
   "transpileDependencies": [

--- a/example/src/components/Demo.vue
+++ b/example/src/components/Demo.vue
@@ -4,17 +4,20 @@
                 voila-url="http://localhost:8000"
                 notebook="bqplot_vuetify_example.ipynb"
                 mount-id="content-main"
+                :request-options=requestOptions
         ></jupyter-widget-embed>
         <jupyter-widget-embed
                 voila-url="http://localhost:8000"
                 notebook="notebook2.ipynb"
                 mount-id="dialog"
+                :request-options=requestOptions
         ></jupyter-widget-embed>
         <jupyter-widget-embed
                 style="margin-top: 40px"
                 voila-url="http://localhost:8000"
                 notebook="bqplot_vuetify_example.ipynb"
                 mount-id="histogram_bins2"
+                :request-options=requestOptions
         ></jupyter-widget-embed>
         <v-card v-if="sliderModel" class="ma-4 mx-auto" width="600">
             <v-card-title class="headline">Access widget models from the page</v-card-title>
@@ -33,6 +36,7 @@
                                 voila-url="http://localhost:8000"
                                 notebook="notebook2.ipynb"
                                 mount-id="event_demo"
+                                :request-options=requestOptions
                         ></jupyter-widget-embed>
                     </v-col>
                     <v-col class="flex-grow-1">
@@ -46,6 +50,7 @@
                                 voila-url="http://localhost:8000"
                                 notebook="notebook2.ipynb"
                                 mount-id="template_event_demo"
+                                :request-options=requestOptions
                         ></jupyter-widget-embed>
                     </v-col>
                     <v-col class="flex-grow-1">
@@ -61,6 +66,7 @@
                         voila-url="http://localhost:8000"
                         notebook="notebook2.ipynb"
                         mount-id="out"
+                        :request-options=requestOptions
                 ></jupyter-widget-embed>
             </v-card-text>
         </v-card>
@@ -79,6 +85,7 @@
             return {
                 sliderModel: null,
                 bins: null,
+                requestOptions: {"credentials": 'include'},
 
                 eventDemoModel: null,
                 templateEventDemoModel: null,

--- a/src/JupyterWidgetEmbed.js
+++ b/src/JupyterWidgetEmbed.js
@@ -26,16 +26,16 @@ function getWidgetManager(voila, kernel) {
                     kernel,
                     kernelChanged: {
                         connect: () => {
-                        }
+                        },
                     },
                     statusChanged: {
                         connect: () => {
-                        }
+                        },
                     },
                 },
                 saveState: {
                     connect: () => {
-                    }
+                    },
                 },
                 /* voila >= 0.2.8 */
                 sessionContext: {
@@ -44,25 +44,25 @@ function getWidgetManager(voila, kernel) {
                     },
                     kernelChanged: {
                         connect: () => {
-                        }
+                        },
                     },
                     statusChanged: {
                         connect: () => {
-                        }
+                        },
                     },
                     connectionStatusChanged: {
                         connect: () => {
-                        }
+                        },
                     },
                 },
             };
 
             const settings = {
-                saveState: false
+                saveState: false,
             };
 
             const rendermime = new voila.RenderMimeRegistry({
-                initialFactories: voila.standardRendererFactories
+                initialFactories: voila.standardRendererFactories,
             });
 
             return new voila.WidgetManager(context, rendermime, settings);
@@ -76,7 +76,7 @@ const notebooksLoaded = {};
 
 let voilaLoaded = false;
 
-async function init(voilaUrl, notebook) {
+async function init(voilaUrl, notebook, requestOptions) {
     addVoilaTags(voilaUrl);
 
     const notebookKey = `${voilaUrl}${notebook}`;
@@ -84,8 +84,7 @@ async function init(voilaUrl, notebook) {
         return;
     }
     notebooksLoaded[notebookKey] = true;
-
-    const res = await fetch(`${voilaUrl}/voila/render/${notebook}`, {credentials: 'include'});
+    const res = await fetch(`${voilaUrl}/voila/render/${notebook}`, requestOptions);
     const json = await res.json();
 
     if (!voilaLoaded) {
@@ -165,7 +164,7 @@ function addVoilaTags(voilaUrl) {
 
 export default {
     name: 'JupyterWidgetEmbed',
-    props: ['voila-url', 'notebook', 'mount-id'],
+    props: ['voila-url', 'notebook', 'mount-id', 'request-options'],
     data() {
         return {
             renderFn: undefined,
@@ -173,7 +172,7 @@ export default {
         };
     },
     created() {
-        init(this.voilaUrl, this.notebook);
+        init(this.voilaUrl, this.notebook, this.requestOptions);
     },
     mounted() {
         requestWidget(this.$props)


### PR DESCRIPTION
This PR closes #2 and updates the JupyterWidgetEmbed code with the latest changes from the original `voila-embed.js` script file in https://github.com/mariobuikhuizen/voila-embed.   

Edit: the example now works for me.